### PR TITLE
Properly handle git-worktree checkouts.

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -14,7 +14,9 @@ impl VCS for Git {
     fn is_repo(&self, path: &str) -> bool {
         let mut pathbuf = PathBuf::from(path);
         pathbuf.push(".git");
-        pathbuf.is_dir()
+        // `.git` is a directory in the root of a normal git repo, and a file in
+        // the root of a git-worktree checkout.
+        pathbuf.is_dir() || pathbuf.is_file()
     }
 
     fn commit(&self, msg: &str) -> Result<(), String> {


### PR DESCRIPTION
When the user has checked out the Gecko or wasmtime tree with
`git-worktree`, the `.git` path in the root of the checkout is actually
a file, not a directory. This PR adjusts the repo-detection logic to
properly recognize this case.